### PR TITLE
Added 2 managed preferences

### DIFF
--- a/application_management/README.md
+++ b/application_management/README.md
@@ -24,6 +24,18 @@ Description: Enforces certain privileges. Whenever **Privileges.app** or the **P
 * **user**: standard user rights are always set by Privileges.
 * **none**: **Privileges.app** and the **PrivilegesCLI** command line tool are disabled and it is not possible to change user privileges using these tools.
 
+Key: **AllowForUser**
+
+Value: Username of single person
+
+Description: This will allow for an MDM such as Jamf to deploy the configuration profile with a variable $USERNAME which will allow only the primary user of the system then to elevate with Privileges
+
+Key: **AllowForGroup**
+
+Value: Local group account name
+
+Description: This will allow for any member of the group to use Privileges. 
+
 Example configuration profiles are available via the link below:
 
 * [Privileges DockToggleTimeout macOS Configuration Profile](example_profiles/DockToggleTimeout/Example_DockToggleTimeout.mobileconfig)

--- a/source/MTAuthCommon.m
+++ b/source/MTAuthCommon.m
@@ -32,7 +32,7 @@ static NSString *kCommandKeyAuthRightDesc = @"authRightDescription";
 
     dispatch_once(&sOnceToken, ^{
         sCommandInfo = @{
-                         NSStringFromSelector(@selector(changeGroupMembershipForUser:group:remove:authorization:withReply:)) : @{
+            NSStringFromSelector(@selector(changeGroupMembershipForUser:group:remove:authorization:timeout:withReply:)) : @{
                                  kCommandKeyAuthRightName    : @"corp.sap.privileges.changeAdminRights",
                                  kCommandKeyAuthRightDefault : @kAuthorizationRuleClassAllow,
                                  kCommandKeyAuthRightDesc    : NSLocalizedString(@"changeAdminRights", nil)

--- a/source/Privileges/AppDelegate.m
+++ b/source/Privileges/AppDelegate.m
@@ -41,6 +41,8 @@
 @property (unsafe_unretained) IBOutlet NSTextView *aboutText;
 @property (weak) IBOutlet NSTextField *appNameAndVersion;
 @property (weak) IBOutlet NSPopUpButton *toggleTimeoutMenu;
+@property (nonatomic, assign) NSInteger timeoutValue;
+@property (nonatomic, assign) BOOL alwaysTimeout;
 @end
 
 extern void CoreDockSendNotification(CFStringRef, void*);
@@ -117,6 +119,8 @@ extern void CoreDockSendNotification(CFStringRef, void*);
             _autoApplyPrivileges = NO;
         }
         
+        _alwaysTimeout = NO;
+        
         [self createDialog];
     }
 }
@@ -125,6 +129,11 @@ extern void CoreDockSendNotification(CFStringRef, void*);
 
 - (void)changeAdminGroup:(NSString*)userName group:(uint)groupID remove:(BOOL)remove
 {
+    uint timeoutValue = 0;
+    if (self->_alwaysTimeout) {
+        timeoutValue = (uint)self->_timeoutValue;
+    }
+    
     [MTAuthCommon connectToHelperToolUsingConnection:&_helperToolConnection
                               andExecuteCommandBlock:^(void) {
         
@@ -133,7 +142,7 @@ extern void CoreDockSendNotification(CFStringRef, void*);
             NSLog(@"SAPCorp: ERROR! %@", proxyError);
             [self displayErrorNotificationAndExit];
             
-        }] changeGroupMembershipForUser:userName group:groupID remove:remove authorization:self->_authorization withReply:^(NSError *error) {
+            }] changeGroupMembershipForUser:userName group:groupID remove:remove authorization:self->_authorization timeout:timeoutValue withReply:^(NSError *error) {
             
             if (error != nil) {
                 NSLog(@"SAPCorp: ERROR! Unable to change privileges: %@", error);
@@ -234,13 +243,13 @@ extern void CoreDockSendNotification(CFStringRef, void*);
 - (void)createTimeoutMenu
 {
     // define the default timeout
-    NSInteger timeoutValue = DEFAULT_DOCK_TIMEOUT;
+    _timeoutValue = DEFAULT_DOCK_TIMEOUT;
     
     // get the configured timeout
     if ([_userDefaults objectForKey:@"DockToggleTimeout"]) {
 
         // get the currently configured timeout
-        timeoutValue = [_userDefaults integerForKey:@"DockToggleTimeout"];
+        _timeoutValue = [_userDefaults integerForKey:@"DockToggleTimeout"];
         
         // disable the menu if the setting is managed
         [_toggleTimeoutMenu setEnabled:![_userDefaults objectIsForcedForKey:@"DockToggleTimeout"]];
@@ -248,7 +257,7 @@ extern void CoreDockSendNotification(CFStringRef, void*);
     } else {
         
         // write the default timeout to file
-        [_userDefaults setValue:[NSNumber numberWithInteger:timeoutValue] forKey:@"DockToggleTimeout"];
+        [_userDefaults setValue:[NSNumber numberWithInteger:self->_timeoutValue] forKey:@"DockToggleTimeout"];
     }
 
     // populate the timeout menu
@@ -262,10 +271,10 @@ extern void CoreDockSendNotification(CFStringRef, void*);
     
     // check if the configured timeout has already an entry in our menu. if not,
     // add the new value and sort the array
-    NSPredicate *predicateString = [NSPredicate predicateWithFormat:@"value == %d", timeoutValue];
+    NSPredicate *predicateString = [NSPredicate predicateWithFormat:@"value == %d", _timeoutValue];
     if ([[self.toggleTimeouts filteredArrayUsingPredicate:predicateString] count] == 0) {
         
-        self.toggleTimeouts = [self.toggleTimeouts arrayByAddingObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInteger:timeoutValue], @"value", [NSString stringWithFormat:@"%ld %@", (long)timeoutValue, NSLocalizedString(@"timeoutMins", nil)], @"name", nil]];
+        self.toggleTimeouts = [self.toggleTimeouts arrayByAddingObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInteger:self->_timeoutValue], @"value", [NSString stringWithFormat:@"%ld %@", (long)_timeoutValue, NSLocalizedString(@"timeoutMins", nil)], @"name", nil]];
         
         // sort the array
         NSSortDescriptor *valueSort = [NSSortDescriptor sortDescriptorWithKey:@"value" ascending:YES];
@@ -276,7 +285,7 @@ extern void CoreDockSendNotification(CFStringRef, void*);
     // our pre-defined list, we add the value to our array, sort it and select the value
     NSUInteger timeoutIndex = [self.toggleTimeouts indexOfObjectPassingTest:^BOOL(NSDictionary *dict, NSUInteger idx, BOOL *stop)
     {
-        return [[dict objectForKey:@"value"] isEqual:[NSNumber numberWithInteger:timeoutValue]];
+        return [[dict objectForKey:@"value"] isEqual:[NSNumber numberWithInteger:_timeoutValue]];
     }];
     if (timeoutIndex != NSNotFound) { [_toggleTimeoutMenu selectItemAtIndex:timeoutIndex]; }
 }
@@ -291,6 +300,12 @@ extern void CoreDockSendNotification(CFStringRef, void*);
     if ([_userDefaults objectIsForcedForKey:@"EnforcePrivileges"]) {
         enforcedPrivileges = [_userDefaults objectForKey:@"EnforcePrivileges"];
     }
+    
+    //
+    if ([_userDefaults boolForKey:@"AlwaysUseTimeout"]) {
+        _alwaysTimeout = [_userDefaults boolForKey:@"AlwaysUseTimeout"];
+    }
+    
     
     // check if the running user is allowed by managed preference
     if ([_userDefaults objectIsForcedForKey:@"AllowForUser"]) {
@@ -590,10 +605,13 @@ extern void CoreDockSendNotification(CFStringRef, void*);
 -(void)applicationWillTerminate:(NSNotification *)aNotification
 {
 #pragma unused(aNotification)
-    // quit the helper tool
-    [MTAuthCommon connectToHelperToolUsingConnection:&_helperToolConnection
-                              andExecuteCommandBlock:^(void) { [[self->_helperToolConnection remoteObjectProxy] quitHelperTool]; }
-     ];
+    if (_timeoutValue <= 0)
+    {
+        // quit the helper tool
+        [MTAuthCommon connectToHelperToolUsingConnection:&_helperToolConnection
+                                  andExecuteCommandBlock:^(void) { [[self->_helperToolConnection remoteObjectProxy] quitHelperTool]; }
+         ];
+    }
     
     // remove our observers
     [_userDefaults removeObserver:self forKeyPath:@"DockToggleTimeout"];

--- a/source/PrivilegesHelper/PrivilegesHelper.h
+++ b/source/PrivilegesHelper/PrivilegesHelper.h
@@ -36,7 +36,7 @@
 - (void)getVersionWithReply:(void(^)(NSString *version))reply;
 
 // changes the group membership for a given user
-- (void)changeGroupMembershipForUser:(NSString*)userName group:(uint)groupID remove:(BOOL)remove authorization:(NSData *)authData withReply:(void(^)(NSError *error))reply;
+- (void)changeGroupMembershipForUser:(NSString*)userName group:(uint)groupID remove:(BOOL)remove authorization:(NSData *)authData timeout:(uint)timeout withReply:(void(^)(NSError *error))reply;
 
 @end
 


### PR DESCRIPTION
In groups where not everyone should be allowed to use admin privileges these settings will restrict the use of the Privileges app and cli to only members of a group or to a single user.

AllowForUser and AllowForGroup

This will allow for an organization to control this with an MDM such as Jamf. By having the AllowForUser the MDM could have a single profile with a variable. Jamf allows you to use $USERNAME to specify the documented primary user of the system as controlled by Jamf and when the profile is deployed with contain the value for that user.

```
  <key>AllowForUser</key>
  <string>$USERNAME</string>
  <key>AllowForGroup</key>
  <string>privileges_user</string>
```
