### PR TITLE
output log type notice to system.log

### DIFF
--- a/source/Privileges/AppDelegate.m
+++ b/source/Privileges/AppDelegate.m
@@ -144,10 +144,10 @@ extern void CoreDockSendNotification(CFStringRef, void*);
                 
                 if (remove) {
                     NSLog(@"SAPCorp: User %@ has now standard user rights", userName);
-                    syslog(LOG_ERR, "SAPCorp: User %s has now standard user rights", userName.description.UTF8String);
+                    syslog(LOG_NOTICE, "SAPCorp: User %s has now standard user rights", userName.description.UTF8String);
                 } else {
                     NSLog(@"SAPCorp: User %@ has now admin rights", userName);
-                    syslog(LOG_ERR, "SAPCorp: User %s has now admin rights", userName.description.UTF8String);
+                    syslog(LOG_NOTICE, "SAPCorp: User %s has now admin rights", userName.description.UTF8String);
 
                 }
                 

--- a/source/Privileges/AppDelegate.m
+++ b/source/Privileges/AppDelegate.m
@@ -20,6 +20,7 @@
 #import "MTAuthCommon.h"
 #import "MTNotification.h"
 #import "PrivilegesHelper.h"
+#include "syslog.h"
 
 @interface AppDelegate ()
 @property (assign) AuthorizationRef authRef;
@@ -143,8 +144,11 @@ extern void CoreDockSendNotification(CFStringRef, void*);
                 
                 if (remove) {
                     NSLog(@"SAPCorp: User %@ has now standard user rights", userName);
+                    syslog(LOG_ERR, "SAPCorp: User %s has now standard user rights", userName.description.UTF8String);
                 } else {
                     NSLog(@"SAPCorp: User %@ has now admin rights", userName);
+                    syslog(LOG_ERR, "SAPCorp: User %s has now admin rights", userName.description.UTF8String);
+
                 }
                 
                 // send a notification to update the Dock tile


### PR DESCRIPTION
Issue: Collection of logs with third party log shippers. With the current implementation. The third-party logs shipper has an external dependency in order to collect the Privilege.app logs (/usr/bin/log)

It is possible to grab the encrypted logs from Unified logs but it introduces overhead and additional moving parts in order aggregate the Priviledge.app logs with a common log shipper. 

Proposition: To add the ability for the Privilege.app to output the logs to system logs. This will allow  third party log shippers input from system.log file, in this case, and easily ingest and ship logs from the app into an aggregation point of choice without any dependencies.

We have experimented with several configurations, one outlined within the following link https://nxlog.co/documentation/nxlog-user-guide/xm_exec.html in combination with the log command with respective subsystems and predicates. 

We would like to know if the maintainers of the project see value in this contribution and would consider the proposed code as a potential feature that can be leveraged by the community as an alternative to ASL / Unified Logs consumption.

Thanks in advance for looking into this.