### PR TITLE
WIP: timeout all uses of Privileges

### DIFF
--- a/source/MTAuthCommon.m
+++ b/source/MTAuthCommon.m
@@ -32,7 +32,7 @@ static NSString *kCommandKeyAuthRightDesc = @"authRightDescription";
 
     dispatch_once(&sOnceToken, ^{
         sCommandInfo = @{
-                         NSStringFromSelector(@selector(changeGroupMembershipForUser:group:remove:authorization:withReply:)) : @{
+            NSStringFromSelector(@selector(changeGroupMembershipForUser:group:remove:authorization:timeout:withReply:)) : @{
                                  kCommandKeyAuthRightName    : @"corp.sap.privileges.changeAdminRights",
                                  kCommandKeyAuthRightDefault : @kAuthorizationRuleClassAllow,
                                  kCommandKeyAuthRightDesc    : NSLocalizedString(@"changeAdminRights", nil)

--- a/source/PrivilegesHelper/PrivilegesHelper.h
+++ b/source/PrivilegesHelper/PrivilegesHelper.h
@@ -36,7 +36,7 @@
 - (void)getVersionWithReply:(void(^)(NSString *version))reply;
 
 // changes the group membership for a given user
-- (void)changeGroupMembershipForUser:(NSString*)userName group:(uint)groupID remove:(BOOL)remove authorization:(NSData *)authData withReply:(void(^)(NSError *error))reply;
+- (void)changeGroupMembershipForUser:(NSString*)userName group:(uint)groupID remove:(BOOL)remove authorization:(NSData *)authData timeout:(uint)timeout withReply:(void(^)(NSError *error))reply;
 
 @end
 


### PR DESCRIPTION
This is not really the best solution for this but might be a good starting point. The thought here is to always timeout the elevation instead of leaving it until the user remove it or they login again.

I'm sure the community at large and even SAP has a better idea on how to implement this. 