### PR TITLE
Allow a url to be used for the logging server

### DIFF
--- a/source/PrivilegesHelper/PrivilegesHelper.m
+++ b/source/PrivilegesHelper/PrivilegesHelper.m
@@ -286,15 +286,15 @@ OSStatus SecTaskValidateForRequirement(SecTaskRef task, CFStringRef requirement)
 
                                 // Get the current system UUID that can be compared with MDM to get device information
                                 io_service_t platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault,IOServiceMatching("IOPlatformExpertDevice"));
-                                CFTypeRef serialNumberAsCFString = nil;
+                                CFTypeRef uniqueDeviceIdAsCFString = nil;
                                 if (platformExpert) {
-                                    serialNumberAsCFString = IORegistryEntryCreateCFProperty(platformExpert, CFSTR(kIOPlatformUUIDKey), kCFAllocatorDefault, 0);
+                                    uniqueDeviceIdAsCFString = IORegistryEntryCreateCFProperty(platformExpert, CFSTR(kIOPlatformUUIDKey), kCFAllocatorDefault, 0);
                                 }
 
                                 IOObjectRelease(platformExpert);
                                 
                                 // Convert POST string parameters to data using UTF8 Encoding
-                                NSString *postParams = [NSString stringWithFormat:@"message=%@&uuid=%@", [logMessage stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet alphanumericCharacterSet]], serialNumberAsCFString];
+                                NSString *postParams = [NSString stringWithFormat:@"message=%@&udid=%@", [logMessage stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet alphanumericCharacterSet]], uniqueDeviceIdAsCFString];
                                 NSData *postData = [postParams dataUsingEncoding:NSUTF8StringEncoding];
 
                                 // Convert POST string parameters to data using UTF8 Encoding


### PR DESCRIPTION
This adds another option for the logging method that will allow for an http POST with params `message` and `udid`. The thought behind adding the UDID would be to use a simple script on the server-side that would interface with the MDM to get the device info that initiated the request and then proceed to log it. For example, we'll use this to send a Slack message to our admins that we can use to go directly to the device in our MDM.

As an example, in jamf, you can easily get the computer details by udid via `https://your-server.jamfcloud.com/JSSResource/computers/udid/{udid}`.

```
<key>RemoteLogging</key>
<dict>
	<key>ServerAddress</key>
	<string>https://example.com/endpoint-path</string>
	<key>ServerType</key>
	<string>http_post</string>
</dict>
```

If this PR is accepted, I'll edit the wiki for this new feature.