### PR TITLE
Do not ignore ToggleTimer when not using the Dock to elevate privileges.

### DIFF
--- a/source/Privileges/Privileges.entitlements
+++ b/source/Privileges/Privileges.entitlements
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request addresses issue #40.

Privileges are automatically removed after the configured timeout regardless how they have been acquired, either by
- control-clicking on the Dock (current behaviour)
- clicking the button in the main application (new behaviour)
- using PrivilegesCLI to elevate privileges (new behaviour)

Privileges are automatically removed after the timeout, even it the computer has been asleep or switched off. This is done by creating a LaunchAgent for the user after privileges have been elevated, which will be triggered in the following circumstances:
- the toggle time has elapsed (by setting StartCalendarInterval): this covers regular use and sleep periods
- the LaunchAgent is loaded (by setting RunAtLoad): this covers shutdowns and reboots

The LaunchAgent calls PrivilegesCLI with a new command line parameter called "expire". This will demote the user only if the timer has elapsed, otherwise do nothing. After demotion the LaunchAgent file will be removed so that it is not executed again.

This is a drop-in replacement for older installations and should even coexist with other methods for demotion, as it simply uses a triggered call to PrivilegesCLI. There are no attempts to detect or prevent "sneaky" behavior , it's simply an extension of the current behaviour. 

However, to be able to create and remove the LaunchAgent in ~/Library/LaunchAgents, the sandboxing entitlement for this app needed to be disabled. As the app itself is designed to elevate privileges this probably can be considered acceptable, but needs discussion.
