### PR TITLE
Enable TLS by default for remote syslog

### DIFF
--- a/application_management/Privileges2_manifest.json
+++ b/application_management/Privileges2_manifest.json
@@ -1516,7 +1516,7 @@
                         "UseTLS": { 
                            "type": "boolean", 
                            "title": "Use TLS", 
-                           "default": false, 
+                           "default": true, 
                            "description": "When set to true, TLS is enabled for the connection. Please make sure your clients have a certificate installed that matches Apple's requirements. Please see https://support.apple.com/en-us/103769 for further information.", 
                            "links": [
                               { 

--- a/application_management/example_profiles/Example_RemoteLogging.mobileconfig
+++ b/application_management/example_profiles/Example_RemoteLogging.mobileconfig
@@ -90,7 +90,9 @@
 									<key>SyslogOptions</key>
 									<dict>
 										<key>ServerPort</key>
-										<integer>514</integer>
+										<integer>6514</integer>
+										<key>UseTLS</key>
+										<true/>
 										<key>LogFacility</key>
 										<integer>4</integer>
 										<key>LogSeverity</key>

--- a/source/Privileges/Privileges.mobileconfig
+++ b/source/Privileges/Privileges.mobileconfig
@@ -697,10 +697,10 @@
                                     
 									<key>SyslogOptions</key>
 									<dict>
-                                        <key>ServerPort</key>
-                                        <integer>514</integer>
                                         <key>UseTLS</key>
-                                        <false/>
+                                        <true/>
+                                        <key>ServerPort</key>
+                                        <integer>6514</integer>
 										<key>LogFacility</key>
 										<integer>4</integer>
 										<key>LogSeverity</key>

--- a/source/PrivilegesAgent/Classes/MTRemoteLoggingManager.m
+++ b/source/PrivilegesAgent/Classes/MTRemoteLoggingManager.m
@@ -58,6 +58,14 @@
             if ([[remoteLoggingConfiguration serverType] isEqualToString:kMTRemoteLoggingServerTypeSyslog]) {
 
                 MTSyslogOptions *syslogOptions = [remoteLoggingConfiguration syslogOptions];
+                
+                if (![syslogOptions useTLS]) {
+                    
+                    NSString *serverAddress = [remoteLoggingConfiguration serverAddress];
+                    NSInteger serverPort = [syslogOptions serverPort];
+                    
+                    os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_ERROR, "SAPCorp: WARNING: Remote syslog for %{public}@:%ld is configured without TLS. Events will be sent in clear text until TLS is enabled.", (serverAddress) ? serverAddress : @"<unknown>", (long)serverPort);
+                }
                 MTSyslog *syslogObject = [[MTSyslog alloc] initWithServerAddress:[remoteLoggingConfiguration serverAddress]
                                                                       serverPort:[syslogOptions serverPort]
                                                                           useTLS:[syslogOptions useTLS]


### PR DESCRIPTION
Changes Introduced:

- Default the managed UseTLS setting for syslog to true and update bundled configuration examples to show TLS on port 6514.

- Log a runtime warning when syslog remains on plaintext so admins don’t miss unsecured deployments.

- Validated plist changes with plutil -lint.