### PR TITLE
fix: enable Tab navigation to buttons in the privileges request popup

### DIFF
--- a/source/Privileges/AppDelegate.m
+++ b/source/Privileges/AppDelegate.m
@@ -20,6 +20,16 @@
 #import "MTReasonAccessoryController.h"
 #import "MTLocalNotification.h"
 #import "Constants.h"
+#import <objc/runtime.h>
+
+// Subclass that allows Tab focus even when the button is disabled, so keyboard
+// users can reach the button and see its state before the reason field is filled.
+@interface MTTabAccessibleButton : NSButton
+@end
+@implementation MTTabAccessibleButton
+- (BOOL)canBecomeKeyView { return YES; }
+- (BOOL)acceptsFirstResponder { return YES; }
+@end
 
 @interface AppDelegate ()
 @property (nonatomic, strong, readwrite) NSWindowController *settingsWindowController;
@@ -224,6 +234,10 @@ extern void CoreDockSendNotification(CFStringRef, void*);
             NSButton *requestButton = [_alert addButtonWithTitle:NSLocalizedString(@"requestButton", nil)];
             [requestButton bind:NSEnabledBinding toObject:self withKeyPath:@"self.enableRequestButton" options:nil];
             [requestButton setHasDestructiveAction:YES];
+            // Allow Tab to land on this button even while it is disabled (e.g. before
+            // the reason field meets the minimum length). The button still won't fire
+            // its action while disabled — this only affects keyboard focus traversal.
+            object_setClass(requestButton, [MTTabAccessibleButton class]);
             
             if ([_privilegesApp reasonRequired]) {
 
@@ -268,7 +282,7 @@ extern void CoreDockSendNotification(CFStringRef, void*);
         }
         
         if (![_privilegesApp hideSettingsButton]) { [_alert addButtonWithTitle:NSLocalizedString(@"settingsButton", nil)]; }
-        NSButton *cancelButton = [_alert addButtonWithTitle:NSLocalizedString(@"cancelButton", nil)];
+        [_alert addButtonWithTitle:NSLocalizedString(@"cancelButton", nil)];
         [_alert setAlertStyle:NSAlertStyleInformational];
         if (![[NSWorkspace sharedWorkspace] isVoiceOverEnabled] && ![_privilegesApp hideHelpButton]) { [_alert setShowsHelp:YES]; }
         [_alert setDelegate:self];
@@ -287,8 +301,7 @@ extern void CoreDockSendNotification(CFStringRef, void*);
                                                             )
             ];
             
-            // make sure the text field is selected
-            [cancelButton setRefusesFirstResponder:YES];
+            // make sure the text field is selected (tab navigation to buttons is still allowed)
         }
     }
 
@@ -303,6 +316,10 @@ extern void CoreDockSendNotification(CFStringRef, void*);
     [transparentDummyWindow setAlphaValue:0];
     [transparentDummyWindow setReleasedWhenClosed:NO];
     [transparentDummyWindow center];
+    // Ensure the alert's own sheet window recalculates its tab (key view) loop so
+    // all controls — including the reason text field and alert buttons — are reachable
+    // via Tab. This must target [_alert window], not the transparent parent window.
+    [[_alert window] setAutorecalculatesKeyViewLoop:YES];
 
     [_alert beginSheetModalForWindow:transparentDummyWindow
                    completionHandler:^(NSModalResponse returnCode) {


### PR DESCRIPTION
## Summary

- `autorecalculatesKeyViewLoop:YES` was being set on `transparentDummyWindow` (the invisible parent window) instead of the alert's own sheet window. The sheet has a separate `NSWindow`, so the parent's setting had no effect on its key view loop.
- `requestButton` is bound to `enableRequestButton` (which starts as `NO` when a reason is required). `NSControl.canBecomeKeyView` returns `NO` for disabled controls, so macOS excluded the button from the tab chain entirely — leaving Tab with nowhere meaningful to go. A small `MTTabAccessibleButton` subclass overrides `canBecomeKeyView` and `acceptsFirstResponder` to return `YES`; `object_setClass` applies it to the existing button instance at runtime without changing its enabled/disabled behaviour or visual state.
- `cancelButton` had `setRefusesFirstResponder:YES` applied whenever an accessory view (reason text field) was present, explicitly excluding it from the responder chain. Removed.

## Test plan

- [ ] Build and launch Privileges with a configuration that requires a reason (`reasonRequired = true`, `reasonMinLength = 3`)
- [ ] Trigger the "Request Privileges" popup
- [ ] With **Keyboard Navigation** enabled (System Settings → Keyboard → Keyboard Navigation), press Tab — focus should cycle through the reason text field, Cancel button, and the (disabled) Request Privileges button
- [ ] Type fewer than `reasonMinLength` characters — Request Privileges button should remain visually disabled and non-activatable via Space/Return
- [ ] Type at least `reasonMinLength` characters — Request Privileges button should enable; Tab to it and press Space/Return should submit
- [ ] Verify the remove-privileges popup (no accessory view) also navigates correctly with Tab

🤖 Generated with [Claude Code](https://claude.ai/claude-code)